### PR TITLE
Convert mysql_ function calls to mysqli_ procedural routines.

### DIFF
--- a/src/class.db.mysql.php
+++ b/src/class.db.mysql.php
@@ -3,9 +3,13 @@
 /*
 	(C) Copyright 2009 Max Pozdeev <maxpozdeev@gmail.com>
 	Licensed under the GNU GPL v2 license. See file COPYRIGHT for details.
+  
+  Edited to replace mysql_ calls with mysqli_ calls, still uses procedural
+  routines.
+  
 */ 
 
-
+// ---------------------------------------------------------------------------- //
 class DatabaseResult_Mysql
 {
 
@@ -21,7 +25,7 @@ class DatabaseResult_Mysql
 		$this->parent = $h;
 		$this->query = $query;
 
-		$this->q = mysql_query($query, $this->parent->dbh);
+		$this->q = mysqli_query($this->parent->dbh ,$query);
 
 		if(!$this->q)
 		{
@@ -33,29 +37,30 @@ class DatabaseResult_Mysql
 	{
 		if(is_null($this->affected))
 		{
-			$this->affected = mysql_affected_rows($this->parent->dbh);
+			$this->affected = mysqli_affected_rows($this->parent->dbh);
 		}
 		return $this->affected;
 	}
 
 	function fetch_row()
 	{
-		return mysql_fetch_row($this->q);
+		return mysqli_fetch_row($this->q);
 	}
 
 	function fetch_assoc()
 	{
-		return mysql_fetch_assoc($this->q);
+		return mysqli_fetch_assoc($this->q);
 	}
 
 	function rows()
 	{
 		if (!is_null($this -> rows)) return $this->rows;
-		$this->rows = mysql_num_rows($this->q);
+		$this->rows = mysqli_num_rows($this->q);
 		return $this->rows;
 	}
 }
 
+// ---------------------------------------------------------------------------- //
 class Database_Mysql
 {
 	var $dbh;
@@ -67,11 +72,11 @@ class Database_Mysql
 
 	function connect($host, $user, $pass, $db)
 	{
-		if(!$this->dbh = @mysql_connect($host,$user,$pass))
+		if(!$this->dbh = @mysqli_connect($host,$user,$pass))
 		{
-			throw new Exception(mysql_error());
+			throw new Exception(mysqli_connect_error());
 		}
-		if( @!mysql_select_db($db, $this->dbh) )
+		if( @!mysqli_select_db($this->dbh, $db) )
 		{
 			throw new Exception($this->error());
 		}
@@ -80,12 +85,12 @@ class Database_Mysql
 
 	function last_insert_id()
 	{
-		return mysql_insert_id($this->dbh);
+		return mysqli_insert_id($this->dbh);
 	}	
 	
 	function error()
 	{
-		return mysql_error($this->dbh);
+		return mysqli_error($this->dbh);
 	}
 
 	function sq($query, $p = NULL)
@@ -93,10 +98,10 @@ class Database_Mysql
 		$q = $this->_dq($query, $p);
 
 		if($q->rows()) $res = $q->fetch_row();
-		else return NULL;
+		  else return NULL;
 
 		if(sizeof($res) > 1) return $res;
-		else return $res[0];
+		  else return $res[0];
 	}
 
 	function sqa($query, $p = NULL)
@@ -104,10 +109,10 @@ class Database_Mysql
 		$q = $this->_dq($query, $p);
 
 		if($q->rows()) $res = $q->fetch_assoc();
-		else return NULL;
+		  else return NULL;
 
 		if(sizeof($res) > 1) return $res;
-		else return $res[0];
+		  else return $res[0];
 	}
 
 	function dq($query, $p = NULL)
@@ -123,7 +128,7 @@ class Database_Mysql
 	private function _dq($query, $p = NULL, $resultless = 0)
 	{
 		if(!isset($p)) $p = array();
-		elseif(!is_array($p)) $p = array($p);
+		  elseif(!is_array($p)) $p = array($p);
 
 		$m = explode('?', $query);
 
@@ -146,7 +151,7 @@ class Database_Mysql
 
 	function affected()
 	{
-		return	mysql_affected_rows($this->dbh);
+		return	mysqli_affected_rows($this->dbh);
 	}
 
 	function quote($s)
@@ -163,9 +168,9 @@ class Database_Mysql
 	function table_exists($table)
 	{
 		$table = addslashes($table);
-		$q = mysql_query("SELECT 1 FROM `$table` WHERE 1=0", $this->dbh);
+		$q = mysqli_query($this->dbh, "SELECT 1 FROM `$table` WHERE 1=0");
 		if($q === false) return false;
-		else return true;
+		  else return true;
 	}
 }
 


### PR DESCRIPTION
Convert the `mysql_` calls that are deprecated in latest versions of php with the procedural `mysqli_` calls to avoid php warnings. Exact one-for-one swap, no other changes.
