### PR TITLE
Fixed #131: Sort tags alphabetically in tag cloud.

### DIFF
--- a/src/includes/api/TagsController.php
+++ b/src/includes/api/TagsController.php
@@ -24,7 +24,7 @@ class TagsController extends ApiController {
                       FROM {$db->prefix}tag2task INNER JOIN {$db->prefix}tags ON tag_id = id
                       $sqlWhere
                       GROUP BY tag_id, name
-                      ORDER BY tags_count DESC");
+                      ORDER BY name ASC");
         $at = array();
         $ac = array();
         while ($r = $q->fetchAssoc()) {


### PR DESCRIPTION
Order tagCloud results by name (ORDER BY name ASC) instead of by usage count so the tag picker matches alphabetical expectations.

Fixed https://github.com/maxpozdeev/mytinytodo/issues/131